### PR TITLE
Update Furmark to newest upstream version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+builddir
+.flatpak-builder

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 builddir
 .flatpak-builder
+export

--- a/com.geeks3d.furmark.metainfo.xml
+++ b/com.geeks3d.furmark.metainfo.xml
@@ -24,6 +24,7 @@
       <li>Stress testing graphic cards to test the reliability of the device or just for fun</li>
       <li>Publishing benchmarking scores</li>
     </ul>
+    <p>The ARM version is still at 2.4.0.0</p>
   </description>
 
   <url type="homepage">https://geeks3d.com/furmark/</url>
@@ -68,6 +69,40 @@
   </content_rating>
   
   <releases>
+    <release version="2.4.1.0" date="2024-10-16" type="stable">
+      <description>
+        <ul>
+          <li>Knot(VK) / furmark-knot-vk demo: fixed artifact scanner false detections on NVIDIA GPUs.</li>
+          <li>fixed a buffer overflow in the Vulkan renderer during the drawing of some meshes (like the knot mesh).</li>
+          <li>fixed the rendering color of the Knot(VK) demo.</li>
+          <li>updated with GPU Shark2 2.4.1.0</li>
+          <li>updated with GeeXLab 0.60.3 libs.</li>
+        </ul>
+      </description>
+    </release>
+
+    <release version="2.4.0.0" date="2024-10-04" type="stable">
+      <description>
+        <ul>
+          <li>fixed a bug in the Knot VK demo: wrong dynamic background was used in benchmark Preset mode.</li>
+          <li>updated GUI (Graphical User Interface): new About box and Settings box.</li>
+          <li>updated the procedure for submitting a score.</li>
+          <li>added monitoring support (usage and power) of recent Intel integrated GPUs like the UHD 770, MTL Arc or LL Arc Graphics 140V/130V.</li>
+          <li>GUI: now temperature and usage sensors of the first monitorable GPU are displayed in the monitoring graph.</li>
+          <li>added screen resolutions: 1280x800 (WXGA), 1280x1024 (SXGA), 1366x768 (HD), 1440x900 (WXGA+), 1536x864, 1600x900 (HD+), 1600x1200 (UXGA), 1680x1050 (WSXGA+), 2048x1152 (QWXGA), 2048x1536 (QXGA) and 2560x1600 (WQXGA).</li>
+          <li>only one instance of furmark.exe is allowed in benchmark mode with Presets.</li>
+          <li>bugfix: in some rare situations (extremely low framerates), the score progress bar went above 100%.</li>
+          <li>removed warning message about the difference between current framerate and average framerate.</li>
+          <li>improved GPU monitoring when several Arc GPUs are present.</li>
+          <li>added VRAM temperature in GPU monitoring section when supported (Intel Arc, AMD Radeon).</li>
+          <li>fixed fan speed display in GPU monitoring section for Intel Arc GPUs.</li>
+          <li>updated with GPU Shark2 2.4.0.0</li>
+          <li>updated with GPU-Z 2.60</li>
+          <li>updated with GeeXLab 0.60.0</li>  
+        </ul>
+      </description>
+    </release>
+
     <release version="2.3.0.0" date="2024-05-06" type="stable">
       <description>
         <ul>

--- a/com.geeks3d.furmark.yml
+++ b/com.geeks3d.furmark.yml
@@ -44,8 +44,8 @@ modules:
 
       - type: archive
         only-arches: [aarch64]
-        url: https://gpumagick.com/downloads/files/2024/furmark2/FurMark_2.4.1.0_rpi64.7z
-        sha256: ef5fbec8ae29ef42dfaae958396db6311775661a2617448e00dd8131279cb215
+        url: https://gpumagick.com/downloads/files/2024/furmark2/FurMark_2.4.0.0_arm64.7z
+        sha256: 6e7a584f279a57a97ae1033fcf2c37543c8a79d40fc5e6df6b9d679f5a7c03da
         dest: furmark
 
       - type: file

--- a/com.geeks3d.furmark.yml
+++ b/com.geeks3d.furmark.yml
@@ -20,6 +20,17 @@ modules:
         url: https://gitlab.freedesktop.org/mesa/glu
         tag: glu-9.0.3
 
+  - name: spoof-caja
+    buildsystem: simple
+    build-commands:
+      - install -Dm755 redirect.sh /app/bin/caja
+
+    sources:
+      - type: script
+        dest-filename: redirect.sh
+        commands:
+          - xdg-open $1
+
   - name: furmark
     buildsystem: simple
     build-commands:

--- a/com.geeks3d.furmark.yml
+++ b/com.geeks3d.furmark.yml
@@ -1,7 +1,7 @@
 id: com.geeks3d.furmark
 
 runtime: org.freedesktop.Platform
-runtime-version: '23.08'
+runtime-version: '24.08'
 sdk: org.freedesktop.Sdk
 
 finish-args:
@@ -13,7 +13,6 @@ finish-args:
 command: FurMark_GUI
 
 modules:
-
   - name: libglu
     buildsystem: meson
     sources:
@@ -26,8 +25,11 @@ modules:
     build-commands:
       - mkdir -p /app/bin
       - cp -r furmark /app/furmark/
-      - chmod +x /app/furmark/FurMark_GUI
       - ln -s /app/furmark/FurMark_GUI /app/bin/FurMark_GUI
+      - ln -s /app/furmark/furmark /app/bin/furmark
+      - touch $XDG_DATA_HOME/gui_log.txt $XDG_DATA_HOME/backend_log.txt
+      - ln -s $XDG_DATA_HOME/gui_log.txt /app/furmark/_geexlab_log.txt
+      - ln -s $XDG_DATA_HOME/backend_log.txt /app/furmark/_furmark_log.txt
       - ffmpeg -i furmark-icon.png -vf scale=512:512 furmark-icon-scaled.png
       - install -Dm644 furmark-icon-scaled.png ${FLATPAK_DEST}/share/icons/hicolor/512x512/apps/${FLATPAK_ID}.png # Install the app icon
       - install -Dm644 com.geeks3d.furmark.desktop ${FLATPAK_DEST}/share/applications/${FLATPAK_ID}.desktop # Install the app menu entry .desktop file
@@ -36,13 +38,13 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://gpumagick.com/downloads/files/2024/furmark2/FurMark_2.3.0.0_linux64.zip
-        sha256: 38a62d3ad41c99b45d36d8a9fdb235f85b5ac7012db39339edcf0f211b38699a
+        url: https://gpumagick.com/downloads/files/2024/furmark2/FurMark_2.4.1.0_linux64.7z
+        sha256: 0cbfba96668add8c1dc495de51be56fd6db5ef2f2c36ee919ab1200854c2d79c
         dest: furmark
 
       - type: archive
         only-arches: [aarch64]
-        url: https://gpumagick.com/downloads/files/2024/furmark2/FurMark_2.3.0.0_rpi64.zip
+        url: https://gpumagick.com/downloads/files/2024/furmark2/FurMark_2.4.1.0_rpi64.7z
         sha256: ef5fbec8ae29ef42dfaae958396db6311775661a2617448e00dd8131279cb215
         dest: furmark
 


### PR DESCRIPTION
Update x86_64 to 2.4.1.0
Update aarch64 to 2.4.0.0
And add redirect from the caja file manager to the proper portal