### PR TITLE
Update to 2.7.0.0

### DIFF
--- a/com.geeks3d.furmark.metainfo.xml
+++ b/com.geeks3d.furmark.metainfo.xml
@@ -25,7 +25,6 @@
       <li>Stress testing graphic cards to test the reliability of the device or just for fun</li>
       <li>Publishing benchmarking scores</li>
     </ul>
-    <p>The ARM version is still at 2.4.0.0</p>
   </description>
 
   <url type="homepage">https://geeks3d.com/furmark/</url>
@@ -78,6 +77,31 @@
   </content_rating>
   
   <releases>    
+    <release version="2.7.0.0" date="2025-03-12" type="stable">
+      <description>
+        <ul>
+          <li>added support of AMD Radeon RX 9070 XT and RX 9070.</li>
+          <li>added support of NVIDIA GeForce RTX 5070.</li>
+          <li>GUI: added custom resolution.</li>
+          <li>GUI (arm64): improved the reactivity.<li>
+          <li>added displaying of MSAA value in the OSI (On Screen Information).</li>
+          <li>added detection of missing ROPs on NVIDIA Blackwell GPUs.</li>
+          <li>restored VRAM and hotspot temperatures reading on NVIDIA GPUs.</li>
+          <li>Hotspot temperature no longer supported on RTX 50 Series.</li>
+          <li>added commercial name:</li>
+          <li>  . ASUS TUF Gaming RX 9070 OC</li>
+          <li>  . SAPPHIRE Nitro+ RX 9070 XT</li>
+          <li>  . XFX RX 9070 Quicksilver</li>
+          <li>  . GIGABYTE RX 9070 XT Gaming OC</li>
+          <li>  . NVIDIA GeForce RTX 5070 Founders Edition</li>
+          <li>  . Zotac RTX 5090 SOLID</li>
+          <li>updated with GPU-Z 2.64</li>
+          <li>updated with GPU Shark2 2.7.0.0</li>
+          <li>updated with GeeXLab 0.63.0 libs.</li>
+        </ul>
+      </description>
+    </release>
+
     <release version="2.6.0.0" date="2025-02-21" type="stable">
       <description>
         <ul>

--- a/com.geeks3d.furmark.metainfo.xml
+++ b/com.geeks3d.furmark.metainfo.xml
@@ -83,7 +83,7 @@
           <li>added support of AMD Radeon RX 9070 XT and RX 9070.</li>
           <li>added support of NVIDIA GeForce RTX 5070.</li>
           <li>GUI: added custom resolution.</li>
-          <li>GUI (arm64): improved the reactivity.<li>
+          <li>GUI (arm64): improved the reactivity.</li>
           <li>added displaying of MSAA value in the OSI (On Screen Information).</li>
           <li>added detection of missing ROPs on NVIDIA Blackwell GPUs.</li>
           <li>restored VRAM and hotspot temperatures reading on NVIDIA GPUs.</li>

--- a/com.geeks3d.furmark.yml
+++ b/com.geeks3d.furmark.yml
@@ -49,14 +49,16 @@ modules:
     sources:
       - type: archive
         only-arches: [x86_64]
-        url: https://geeks3d.com/downloads/2025/fm2/FurMark_2.6.0.0_linux64.7z
-        sha256: d7c88d080c80f71bd7ff7a03de5b3b9fba97419885ab8ea46f26d8ef0fc7f18f
+        url: https://geeks3d.com/dl/get/797
+        sha256: ab482d58115aa8fb332392102a5ca5af8746ece383cc09f39b90cf5c1a99afad
+        dest-filename: furmark.7z
         dest: furmark
 
       - type: archive
         only-arches: [aarch64]
-        url: https://gpumagick.com/downloads/files/2024/furmark2/FurMark_2.4.0.0_arm64.7z
-        sha256: 6e7a584f279a57a97ae1033fcf2c37543c8a79d40fc5e6df6b9d679f5a7c03da
+        url: https://geeks3d.com/dl/get/798
+        sha256: f2039230cecb46c294ff632cc04a5adaba7fba39f3b6c775b585e268162991a5
+        dest-filename: furmark.7z
         dest: furmark
 
       - type: file


### PR DESCRIPTION
The direct download link doesn't seem to work anymore for the new version, so it had to be changed to the shortlink from their website that redirects to the file.
They've also updated the ARM version (though I don't have a system to test this on)